### PR TITLE
Added brand to search

### DIFF
--- a/lib/ApaiIO/Operations/Search.php
+++ b/lib/ApaiIO/Operations/Search.php
@@ -61,6 +61,23 @@ class Search extends AbstractOperation
         return $this;
     }
     
+    
+    /**
+     * Sets the brand
+     *
+     * @param string $brand
+     *
+     * @return \ApaiIO\Operations\Search
+     */
+    public function setKeywords($brand)
+    {
+        $this->parameter['Brand'] = $brand;
+
+        return $this;
+    }
+    
+    
+    
     /**
      * Sets the response group
      *


### PR DESCRIPTION
Missing Brand in search.
There are actually a lot of missing Request Parameters is the Search class.

http://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html
